### PR TITLE
fix: Check season instead of build

### DIFF
--- a/ShadowlandsSeason4EncounterJournal.lua
+++ b/ShadowlandsSeason4EncounterJournal.lua
@@ -1,4 +1,5 @@
-if GetBuildInfo() ~= "9.2.5" then return end -- addon obsolete in Dragonflight!
+local isShadowlandsSeason4 = C_MythicPlus.GetCurrentSeasonValues() == 8
+if not isShadowlandsSeason4 then return end -- addon obsolete once the season is over!
 
 local doOnce = true
 


### PR DESCRIPTION
9.2.7 is on the PTR and would break the addon currently, also Season 4 will presumably still be active during the Dragonflight prepatch.